### PR TITLE
Add non ascii character word joiner to the text cleanup

### DIFF
--- a/lib/src/generator.dart
+++ b/lib/src/generator.dart
@@ -64,7 +64,8 @@ class Generator {
         .replaceAll("´", "'")
         .replaceAll("»", '"')
         .replaceAll(" ", ' ')
-        .replaceAll("•", '.');
+        .replaceAll("•", '.')
+        .replaceAll("⁠", '');
     if (!isKanji) {
       return latin1.encode(text);
     } else {


### PR DESCRIPTION
Added unicode WJ(word joiner) to the text cleanup before passing to ```latin1.encode(text)```.

It causes a crash otherwise in case WJ is part of the text